### PR TITLE
Changed best practices link

### DIFF
--- a/code-review-checklist.md
+++ b/code-review-checklist.md
@@ -171,4 +171,4 @@ reviewer should ask him or herself about the code under review.
 
 
 [QMS_info]: http://gin.bcgsc.ca/plone/groups/quality/bioinformatics-quality-assurance/documents
-[Whitepaper]: http://gin.bcgsc.ca/jira/secure/attachment/32569/WP-CC-11-Best-Practices-of-Peer-Code-Review.pdf
+[Whitepaper]: https://support.smartbear.com/support/media/resources/cc/11_Best_Practices_for_Peer_Code_Review.pdf


### PR DESCRIPTION
The link to the PDF goes to a secure link which is not accessible by the public. The link in this pull request goes to an open PDF.